### PR TITLE
Updating README to make sure users will install Sinon on their projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation
 Install the module via npm
 
 ```sh
-$ npm install karma-sinon --save-dev
+$ npm install karma-sinon sinon --save-dev
 ```
 
 Add `sinon` to the `frameworks` key in your Karma configuration:


### PR DESCRIPTION
Since `karma-sinon` has a peerDependency for `sinon` with `*`, I think it would be a good idea instructing users to install `sinon` on their projects, to avoid problems when the lib updates. I've had this problem more than once: https://github.com/sinonjs/sinon/issues/1040